### PR TITLE
Fix bug: close st_connector in on_msg or on_msg_handle will cause it …

### DIFF
--- a/asio_server/asio_server.cpp
+++ b/asio_server/asio_server.cpp
@@ -113,6 +113,14 @@ class echo_server : public st_server_base<echo_socket, st_object_pool<echo_socke
 public:
 	echo_server(st_service_pump& service_pump_) : st_server_base(service_pump_) {}
 
+	boost::posix_time::time_duration recv_idle_time()
+	{
+		boost::posix_time::time_duration time_recv_idle;
+		ST_THIS do_something_to_all([&time_recv_idle](object_ctype& item) {time_recv_idle += item->recv_idle_time();});
+
+		return time_recv_idle;
+	}
+
 	//from i_echo_server, pure virtual function, we must implement it.
 	virtual void test() {/*puts("in echo_server::test()");*/}
 };
@@ -163,6 +171,9 @@ int main(int argc, const char* argv[])
 		{
 			printf("normal server, link #: " ST_ASIO_SF ", closed links: " ST_ASIO_SF "\n", server_.size(), server_.closed_object_size());
 			printf("echo server, link #: " ST_ASIO_SF ", closed links: " ST_ASIO_SF "\n", echo_server_.size(), echo_server_.closed_object_size());
+			boost::posix_time::time_duration time_recv_idle = echo_server_.recv_idle_time();
+			printf("recv idle time: %d:%d:%d %f\n", time_recv_idle.hours(), time_recv_idle.minutes(), time_recv_idle.seconds(),
+				time_recv_idle.fractional_seconds() / pow(10., boost::posix_time::time_duration::num_fractional_digits()));
 		}
 		//the following two commands demonstrate how to suspend msg dispatching, no matter recv buffer been used or not
 		else if (str == SUSPEND_COMMAND)

--- a/compatible_edition/asio_server/asio_server.cpp
+++ b/compatible_edition/asio_server/asio_server.cpp
@@ -115,6 +115,16 @@ class echo_server : public echo_server_base
 public:
 	echo_server(st_service_pump& service_pump_) : echo_server_base(service_pump_) {}
 
+	boost::posix_time::time_duration recv_idle_time()
+	{
+		boost::posix_time::time_duration time_recv_idle;
+		boost::shared_lock<boost::shared_mutex> lock(ST_THIS object_can_mutex);
+		for (BOOST_AUTO(iter, ST_THIS object_can.begin()); iter != ST_THIS object_can.end(); ++iter)
+			time_recv_idle += (*iter)->recv_idle_time();
+
+		return time_recv_idle;
+	}
+
 	//from i_echo_server, pure virtual function, we must implement it.
 	virtual void test() {/*puts("in echo_server::test()");*/}
 };
@@ -165,6 +175,9 @@ int main(int argc, const char* argv[])
 		{
 			printf("normal server, link #: " ST_ASIO_SF ", closed links: " ST_ASIO_SF "\n", server_.size(), server_.closed_object_size());
 			printf("echo server, link #: " ST_ASIO_SF ", closed links: " ST_ASIO_SF "\n", echo_server_.size(), echo_server_.closed_object_size());
+			boost::posix_time::time_duration time_recv_idle = echo_server_.recv_idle_time();
+			printf("recv idle time: %d:%d:%d %f\n", time_recv_idle.hours(), time_recv_idle.minutes(), time_recv_idle.seconds(),
+				time_recv_idle.fractional_seconds() / pow(10., boost::posix_time::time_duration::num_fractional_digits()));
 		}
 		//the following two commands demonstrate how to suspend msg dispatching, no matter recv buffer been used or not
 		else if (str == SUSPEND_COMMAND)

--- a/compatible_edition/file_client/file_client.h
+++ b/compatible_edition/file_client/file_client.h
@@ -190,8 +190,8 @@ public:
 	fl_type get_total_rest_size()
 	{
 		fl_type total_rest_size = 0;
-		do_something_to_all(boost::ref(total_rest_size) += *boost::lambda::_1);
-//		do_something_to_all(boost::ref(total_rest_size) += boost::lambda::bind(&file_socket::get_rest_size, &*boost::lambda::_1));
+		do_something_to_all(total_rest_size += *boost::lambda::_1);
+//		do_something_to_all(total_rest_size += boost::lambda::bind(&file_socket::get_rest_size, &*boost::lambda::_1));
 
 		return total_rest_size;
 	}

--- a/compatible_edition/include/st_asio_wrapper_client.h
+++ b/compatible_edition/include/st_asio_wrapper_client.h
@@ -31,7 +31,7 @@ public:
 	st_sclient(st_service_pump& service_pump_, Arg& arg) : i_service(service_pump_), Socket(service_pump_, arg) {}
 
 protected:
-	virtual bool init() {ST_THIS reset(); ST_THIS start(); ST_THIS send_msg(); return Socket::started();}
+	virtual bool init() {ST_THIS reset(); ST_THIS start(); return Socket::started();}
 	virtual void uninit() {ST_THIS graceful_close();}
 };
 
@@ -50,8 +50,6 @@ protected:
 	{
 		ST_THIS do_something_to_all(boost::mem_fn(&Socket::reset));
 		ST_THIS do_something_to_all(boost::mem_fn(&Socket::start));
-		ST_THIS do_something_to_all(boost::mem_fn((bool (Socket::*)()) &Socket::send_msg));
-
 		ST_THIS start();
 		return true;
 	}

--- a/compatible_edition/include/st_asio_wrapper_connector.h
+++ b/compatible_edition/include/st_asio_wrapper_connector.h
@@ -78,6 +78,7 @@ public:
 		st_tcp_socket_base<Socket, Packer, Unpacker>::force_close();
 	}
 
+	//sync must be false if you call graceful_close in on_msg
 	void graceful_close(bool reconnect = false, bool sync = true)
 	{
 		if (ST_THIS is_closing())
@@ -114,7 +115,7 @@ protected:
 	{
 		if (!ST_THIS get_io_service().stopped())
 		{
-			if (!is_connected())
+			if (reconnecting && !is_connected())
 				ST_THIS lowest_layer().async_connect(server_addr, boost::bind(&st_connector_base::connect_handler, this, boost::asio::placeholders::error));
 			else
 				ST_THIS do_recv_msg();

--- a/compatible_edition/include/st_asio_wrapper_server_socket.h
+++ b/compatible_edition/include/st_asio_wrapper_server_socket.h
@@ -36,7 +36,6 @@ public:
 	static const unsigned char TIMER_END = TIMER_BEGIN + 10;
 
 	st_server_socket_base(Server& server_) : st_tcp_socket_base<Socket, Packer, Unpacker>(server_.get_service_pump()), server(server_) {}
-
 	template<typename Arg>
 	st_server_socket_base(Server& server_, Arg& arg) : st_tcp_socket_base<Socket, Packer, Unpacker>(server_.get_service_pump(), arg), server(server_) {}
 

--- a/compatible_edition/include/st_asio_wrapper_udp_socket.h
+++ b/compatible_edition/include/st_asio_wrapper_udp_socket.h
@@ -121,13 +121,7 @@ protected:
 	{
 		if (!ST_THIS get_io_service().stopped())
 		{
-			ST_THIS next_layer().async_receive_from(unpacker_->prepare_next_recv(), peer_addr,
-				boost::bind(&st_udp_socket_base::recv_handler, this,
-#ifdef ST_ASIO_ENHANCED_STABILITY
-					ST_THIS async_call_indicator,
-#endif
-					boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-
+			do_recv_msg();
 			return true;
 		}
 
@@ -153,6 +147,16 @@ protected:
 		}
 
 		return ST_THIS sending;
+	}
+
+	virtual void do_recv_msg()
+	{
+		ST_THIS next_layer().async_receive_from(unpacker_->prepare_next_recv(), peer_addr,
+			boost::bind(&st_udp_socket_base::recv_handler, this,
+#ifdef ST_ASIO_ENHANCED_STABILITY
+				ST_THIS async_call_indicator,
+#endif
+				boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 	}
 
 	virtual bool is_send_allowed() const {return ST_THIS lowest_layer().is_open() && st_socket<Socket, Packer, Unpacker, in_msg_type, out_msg_type>::is_send_allowed();}
@@ -186,7 +190,7 @@ protected:
 private:
 	void recv_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{
@@ -206,7 +210,7 @@ private:
 
 	void send_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{

--- a/include/st_asio_wrapper_client.h
+++ b/include/st_asio_wrapper_client.h
@@ -31,7 +31,7 @@ public:
 	st_sclient(st_service_pump& service_pump_, Arg& arg) : i_service(service_pump_), Socket(service_pump_, arg) {}
 
 protected:
-	virtual bool init() {ST_THIS reset(); ST_THIS start(); ST_THIS send_msg(); return Socket::started();}
+	virtual bool init() {ST_THIS reset(); ST_THIS start(); return Socket::started();}
 	virtual void uninit() {ST_THIS graceful_close();}
 };
 
@@ -48,10 +48,7 @@ protected:
 
 	virtual bool init()
 	{
-		ST_THIS do_something_to_all([](typename Pool::object_ctype& item) {item->reset();});
-		ST_THIS do_something_to_all([](typename Pool::object_ctype& item) {item->start();});
-		ST_THIS do_something_to_all([](typename Pool::object_ctype& item) {item->send_msg();});
-
+		ST_THIS do_something_to_all([](typename Pool::object_ctype& item) {item->reset(); item->start();});
 		ST_THIS start();
 		return true;
 	}

--- a/include/st_asio_wrapper_connector.h
+++ b/include/st_asio_wrapper_connector.h
@@ -78,6 +78,7 @@ public:
 		st_tcp_socket_base<Socket, Packer, Unpacker>::force_close();
 	}
 
+	//sync must be false if you call graceful_close in on_msg
 	void graceful_close(bool reconnect = false, bool sync = true)
 	{
 		if (ST_THIS is_closing())
@@ -114,7 +115,7 @@ protected:
 	{
 		if (!ST_THIS get_io_service().stopped())
 		{
-			if (!is_connected())
+			if (reconnecting && !is_connected())
 				ST_THIS lowest_layer().async_connect(server_addr, boost::bind(&st_connector_base::connect_handler, this, boost::asio::placeholders::error));
 			else
 				ST_THIS do_recv_msg();

--- a/include/st_asio_wrapper_server_socket.h
+++ b/include/st_asio_wrapper_server_socket.h
@@ -36,7 +36,6 @@ public:
 	static const unsigned char TIMER_END = TIMER_BEGIN + 10;
 
 	st_server_socket_base(Server& server_) : st_tcp_socket_base<Socket, Packer, Unpacker>(server_.get_service_pump()), server(server_) {}
-
 	template<typename Arg>
 	st_server_socket_base(Server& server_, Arg& arg) : st_tcp_socket_base<Socket, Packer, Unpacker>(server_.get_service_pump(), arg), server(server_) {}
 

--- a/include/st_asio_wrapper_socket.h
+++ b/include/st_asio_wrapper_socket.h
@@ -42,7 +42,6 @@ protected:
 	static const unsigned char TIMER_END = TIMER_BEGIN + 10;
 
 	st_socket(boost::asio::io_service& io_service_) : st_timer(io_service_), _id(-1), next_layer_(io_service_), packer_(boost::make_shared<Packer>()) {init();}
-
 	template<typename Arg>
 	st_socket(boost::asio::io_service& io_service_, Arg& arg) : st_timer(io_service_), _id(-1), next_layer_(io_service_, arg), packer_(boost::make_shared<Packer>()) {init();}
 
@@ -52,6 +51,8 @@ protected:
 		sending = suspend_send_msg_ = false;
 		dispatching = suspend_dispatch_msg_ = false;
 		started_ = false;
+
+		time_recv_idle = boost::posix_time::time_duration();
 	}
 
 	void clear_buffer()
@@ -75,13 +76,8 @@ public:
 
 	virtual bool obsoleted()
 	{
-		if (started())
+		if (started() || ST_THIS is_async_calling())
 			return false;
-
-#ifdef ST_ASIO_ENHANCED_STABILITY
-		if (!async_call_indicator.unique())
-			return false;
-#endif
 
 		boost::unique_lock<boost::shared_mutex> lock(recv_msg_buffer_mutex, boost::try_to_lock);
 		return lock.owns_lock() && recv_msg_buffer.empty(); //if successfully locked, means this st_socket is idle
@@ -110,6 +106,8 @@ public:
 		do_dispatch_msg(true);
 	}
 	bool suspend_dispatch_msg() const {return suspend_dispatch_msg_;}
+
+	boost::posix_time::time_duration recv_idle_time() const {return time_recv_idle;}
 
 	//get or change the packer at runtime
 	//changing packer at runtime is not thread-safe, please pay special attention
@@ -165,6 +163,7 @@ public:
 protected:
 	virtual bool do_start() = 0;
 	virtual bool do_send_msg() = 0; //must mutex send_msg_buffer before invoke this function
+	virtual void do_recv_msg() = 0;
 
 	virtual bool is_send_allowed() const {return !suspend_send_msg_;} //can send msg or not(just put into send buffer)
 
@@ -235,7 +234,7 @@ protected:
 #endif
 
 		if (temp_msg_buffer.empty())
-			do_start(); //receive msg sequentially, which means second receiving only after first receiving success
+			do_recv_msg(); //receive msg sequentially, which means second receiving only after first receiving success
 		else
 			set_timer(TIMER_DISPATCH_MSG, 50, [this](unsigned char id)->bool {return ST_THIS timer_handler(id);});
 	}
@@ -253,9 +252,8 @@ protected:
 		}
 		else if (!posting)
 		{
-			auto& io_service_ = get_io_service();
 			auto dispatch_all = false;
-			if (io_service_.stopped())
+			if (get_io_service().stopped())
 				dispatch_all = !(dispatching = false);
 			else if (!dispatching)
 			{
@@ -265,18 +263,13 @@ protected:
 				{
 					dispatching = true;
 					last_dispatch_msg.swap(recv_msg_buffer.front());
-					io_service_.post([this]() {ST_THIS msg_handler();});
+					post([this]() {ST_THIS msg_handler();});
 					recv_msg_buffer.pop_front();
 				}
 			}
 
 			if (dispatch_all)
 			{
-#ifdef ST_ASIO_FORCE_TO_USE_MSG_RECV_BUFFER
-				//the msgs in temp_msg_buffer are discarded if we don't used msg receive buffer, it's very hard to resolve this defect,
-				//so, please be very carefully if you decide to resolve this issue, the biggest problem is calling force_close in on_msg.
-				recv_msg_buffer.splice(std::end(recv_msg_buffer), temp_msg_buffer);
-#endif
 #ifndef ST_ASIO_DISCARD_MSG_WHEN_LINK_DOWN
 				st_asio_wrapper::do_something_to_all(recv_msg_buffer, [this](OutMsgType& msg) {ST_THIS on_msg_handle(msg, true);});
 #endif
@@ -318,9 +311,7 @@ protected:
 	void init()
 	{
 		reset_state();
-#ifdef ST_ASIO_ENHANCED_STABILITY
-		async_call_indicator = boost::make_shared<char>('\0');
-#endif
+		st_timer::init();
 	}
 
 private:
@@ -329,6 +320,7 @@ private:
 		switch (id)
 		{
 		case TIMER_DISPATCH_MSG: //delay putting msgs into receive buffer cause of receive buffer overflow
+			time_recv_idle += boost::posix_time::milliseconds(50);
 			dispatch_msg();
 			break;
 		case TIMER_SUSPEND_DISPATCH_MSG: //suspend dispatching msgs
@@ -354,6 +346,7 @@ private:
 			}
 			break;
 		case TIMER_RE_DISPATCH_MSG: //re-dispatch
+			time_recv_idle += boost::posix_time::milliseconds(50);
 			do_dispatch_msg(true);
 			break;
 		default:
@@ -404,9 +397,8 @@ protected:
 	bool started_; //has started or not
 	boost::shared_mutex start_mutex;
 
-#ifdef ST_ASIO_ENHANCED_STABILITY
-	boost::shared_ptr<char> async_call_indicator;
-#endif
+	//during this duration, st_socket suspended msg reception because of receiving buffer was full.
+	boost::posix_time::time_duration time_recv_idle;
 };
 
 } //namespace

--- a/include/st_asio_wrapper_ssl.h
+++ b/include/st_asio_wrapper_ssl.h
@@ -152,7 +152,6 @@ public:
 	boost::asio::ssl::context& ssl_context() {return ctx;}
 
 	typename st_ssl_object_pool::object_type create_object() {auto object_ptr = boost::make_shared<Object>(ST_THIS service_pump, ctx); return ST_THIS post_create(object_ptr), object_ptr;}
-
 	template<typename Arg>
 	typename st_ssl_object_pool::object_type create_object(Arg& arg) {auto object_ptr = boost::make_shared<Object>(arg, ctx); return ST_THIS post_create(object_ptr), object_ptr;}
 

--- a/include/st_asio_wrapper_tcp_socket.h
+++ b/include/st_asio_wrapper_tcp_socket.h
@@ -43,7 +43,6 @@ protected:
 	using st_socket<Socket, Packer, Unpacker>::TIMER_END;
 
 	st_tcp_socket_base(boost::asio::io_service& io_service_) : st_socket<Socket, Packer, Unpacker>(io_service_), unpacker_(boost::make_shared<Unpacker>()) {reset_state(); close_state = 0;}
-
 	template<typename Arg>
 	st_tcp_socket_base(boost::asio::io_service& io_service_, Arg& arg) : st_socket<Socket, Packer, Unpacker>(io_service_, arg), unpacker_(boost::make_shared<Unpacker>()) {reset_state(); close_state = 0;}
 
@@ -135,6 +134,19 @@ protected:
 		return ST_THIS sending;
 	}
 
+	virtual void do_recv_msg()
+	{
+		auto recv_buff = unpacker_->prepare_next_recv();
+		if (boost::asio::buffer_size(recv_buff) > 0)
+			boost::asio::async_read(ST_THIS next_layer(), recv_buff,
+				boost::bind(&i_unpacker<out_msg_type>::completion_condition, unpacker_, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred),
+				boost::bind(&st_tcp_socket_base::recv_handler, this,
+#ifdef ST_ASIO_ENHANCED_STABILITY
+					ST_THIS async_call_indicator,
+#endif
+					boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
+	}
+
 	virtual bool is_send_allowed() const {return !is_closing() && st_socket<Socket, Packer, Unpacker>::is_send_allowed();}
 	//can send data or not(just put into send buffer)
 
@@ -147,21 +159,6 @@ protected:
 #endif
 
 	virtual bool on_msg_handle(out_msg_type& msg, bool link_down) {unified_out::debug_out("recv(" ST_ASIO_SF "): %s", msg.size(), msg.data()); return true;}
-
-	//start the asynchronous read
-	//it's child's responsibility to invoke this properly, because st_tcp_socket_base doesn't know any of the connection status
-	void do_recv_msg()
-	{
-		auto recv_buff = unpacker_->prepare_next_recv();
-		if (boost::asio::buffer_size(recv_buff) > 0)
-			boost::asio::async_read(ST_THIS next_layer(), recv_buff,
-				boost::bind(&i_unpacker<out_msg_type>::completion_condition, unpacker_, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred),
-				boost::bind(&st_tcp_socket_base::recv_handler, this,
-#ifdef ST_ASIO_ENHANCED_STABILITY
-					ST_THIS async_call_indicator,
-#endif
-					boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-	}
 
 	void clean_up()
 	{
@@ -180,7 +177,7 @@ protected:
 private:
 	void recv_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{
@@ -202,7 +199,7 @@ private:
 
 	void send_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{

--- a/include/st_asio_wrapper_udp_socket.h
+++ b/include/st_asio_wrapper_udp_socket.h
@@ -121,13 +121,7 @@ protected:
 	{
 		if (!ST_THIS get_io_service().stopped())
 		{
-			ST_THIS next_layer().async_receive_from(unpacker_->prepare_next_recv(), peer_addr,
-				boost::bind(&st_udp_socket_base::recv_handler, this,
-#ifdef ST_ASIO_ENHANCED_STABILITY
-					ST_THIS async_call_indicator,
-#endif
-					boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
-
+			do_recv_msg();
 			return true;
 		}
 
@@ -153,6 +147,16 @@ protected:
 		}
 
 		return ST_THIS sending;
+	}
+
+	virtual void do_recv_msg()
+	{
+		ST_THIS next_layer().async_receive_from(unpacker_->prepare_next_recv(), peer_addr,
+			boost::bind(&st_udp_socket_base::recv_handler, this,
+#ifdef ST_ASIO_ENHANCED_STABILITY
+				ST_THIS async_call_indicator,
+#endif
+				boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 	}
 
 	virtual bool is_send_allowed() const {return ST_THIS lowest_layer().is_open() && st_socket<Socket, Packer, Unpacker, in_msg_type, out_msg_type>::is_send_allowed();}
@@ -186,7 +190,7 @@ protected:
 private:
 	void recv_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{
@@ -206,7 +210,7 @@ private:
 
 	void send_handler(
 #ifdef ST_ASIO_ENHANCED_STABILITY
-		boost::shared_ptr<char> async_call_indicator,
+		const boost::shared_ptr<char>& async_call_indicator,
 #endif
 		const boost::system::error_code& ec, size_t bytes_transferred)
 	{

--- a/test_client/test_client.cpp
+++ b/test_client/test_client.cpp
@@ -141,6 +141,14 @@ public:
 		return total_recv_bytes;
 	}
 
+	boost::posix_time::time_duration recv_idle_time()
+	{
+		boost::posix_time::time_duration time_recv_idle;
+		ST_THIS do_something_to_all([&time_recv_idle](object_ctype& item) {time_recv_idle += item->recv_idle_time();});
+
+		return time_recv_idle;
+	}
+
 	void clear_status() {do_something_to_all([](object_ctype& item) {item->clear_status();});}
 	void begin(size_t msg_num, size_t msg_len, char msg_fill) {do_something_to_all([=](object_ctype& item) {item->begin(msg_num, msg_len, msg_fill);});}
 
@@ -233,7 +241,12 @@ int main(int argc, const char* argv[])
 			service_pump.start_service(min_thread_num);
 		}
 		else if (str == LIST_STATUS)
+		{
 			printf("link #: " ST_ASIO_SF ", valid links: " ST_ASIO_SF ", closed links: " ST_ASIO_SF "\n", client.size(), client.valid_size(), client.closed_object_size());
+			boost::posix_time::time_duration time_recv_idle = client.recv_idle_time();
+			printf("recv idle time: %d:%d:%d %f\n", time_recv_idle.hours(), time_recv_idle.minutes(), time_recv_idle.seconds(),
+				time_recv_idle.fractional_seconds() / pow(10., boost::posix_time::time_duration::num_fractional_digits()));
+		}
 		//the following two commands demonstrate how to suspend msg dispatching, no matter recv buffer been used or not
 		else if (str == SUSPEND_COMMAND)
 			client.do_something_to_all([](test_client::object_ctype& item) {item->suspend_dispatch_msg(true);});


### PR DESCRIPTION
…reconnect the server even you don't intend to.

Guarantee absolute safety when freeing or reusing st_socket, just need to define ST_ASIO_ENHANCED_STABILITY macro.
Add statistics of idle time on data reception.